### PR TITLE
fix: cloud functions svelte-kit config update

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,7 @@
 {
 
   "functions": {
+    "source": "functions",
     "predeploy": [
       "npm --prefix \"$RESOURCE_DIR\" run lint",
       "npm --prefix \"$RESOURCE_DIR\" run build"
@@ -19,7 +20,7 @@
     "rewrites": [
       {
         "source": "**",
-        "function": "index"
+        "function": "sveltekit"
       }
     ]
   },


### PR DESCRIPTION
To complete the configuration for the `svelte-adapter-firebase` the following configuration is required to be explicit:

- `firebase.json:functions.source`: the current config falls back on the default of `functions`, the adapter requires it to be explicitly added.
- `firebase.json:hosting.rewrites[].function`: should the name used to export the Cloud Function HTTPS handler. That is, `exports.date = functions.https.onRequest` _date_ is the name in this example. The rewrite rule expects a name like this. `sveltekit` is a good placeholder as it's unlikely to conflict.

---

I will be re-writing the logs of the adapter with clearer examples at each step.